### PR TITLE
Give keyboard focus when placed in the overlay layer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -457,6 +457,10 @@ create_dialog (void)
   gtk_window_set_skip_taskbar_hint (GTK_WINDOW (dlg), options.data.skip_taskbar);
   gtk_window_set_skip_pager_hint (GTK_WINDOW (dlg), options.data.skip_taskbar);
   gtk_window_set_accept_focus (GTK_WINDOW (dlg), options.data.focus);
+#ifdef HAVE_GTK_LAYER_SHELL
+  if (options.data.focus && (layer != GTK_LAYER_SHELL_LAYER_ENTRY_NUMBER || edge != GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER || corner != GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER))
+    gtk_layer_set_keyboard_mode (GTK_WINDOW (dlg), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
+#endif
 
   /* create box */
 #if !GTK_CHECK_VERSION(3,0,0)


### PR DESCRIPTION
I'm using yad for a screen capture tool which shows an overlay window at the bottom of the screen, and it can't be closed with Esc.

By default, windows in the overlay layer don't get keyboard focus, so you must use the mouse to close this dialog, even if you invoke the screenshot tool using the PrtScn key, and this is annoying.

This PR makes windows with layer-shell attributes set receive keyboard focus, unless `--no-focus` was specified.

![1](https://github.com/user-attachments/assets/7e79ed3a-583a-4bc5-833f-6e2c3dc3a4ec)
